### PR TITLE
Fixed issue with regex does not match name spaced models.

### DIFF
--- a/exe/build_memory_report
+++ b/exe/build_memory_report
@@ -18,9 +18,8 @@ assests_path = File.join(Gem.loaded_specs['rails_memory_bloat'].full_gem_path, "
 system('mkdir', '-p', "#{output}/data")
 system('cp', '-r', assests_path, "#{output}/assets")
 
-File.open(log, 'r').each_line do |line|
-  next unless line[0, 14] == '[Memory Usage]'
-  request = ReportGenerator::Request.new(line)
+File.open(log,'r').grep(/Memory Usage/).each do |line|
+  ReportGenerator::Request.new(line)
 end
 
 ReportGenerator::RailsProcess.instances.each do |process|

--- a/exe/build_memory_report
+++ b/exe/build_memory_report
@@ -18,8 +18,9 @@ assests_path = File.join(Gem.loaded_specs['rails_memory_bloat'].full_gem_path, "
 system('mkdir', '-p', "#{output}/data")
 system('cp', '-r', assests_path, "#{output}/assets")
 
-File.open(log,'r').grep(/Memory Usage/).each do |line|
-  ReportGenerator::Request.new(line)
+File.open(log, 'r').each_line do |line|
+  next unless line[0, 14] == '[Memory Usage]'
+  request = ReportGenerator::Request.new(line)
 end
 
 ReportGenerator::RailsProcess.instances.each do |process|

--- a/lib/report_generator/request.rb
+++ b/lib/report_generator/request.rb
@@ -16,7 +16,7 @@ module ReportGenerator
       pid, @project, @user_id, @rss = [$1, $2, $3, $4].map(&:to_i)
       @process = ReportGenerator::RailsProcess.find(pid)
 
-      unless log_string =~ /Records: \(((\d+)( \| \w+: \d+)*)\); (.+)/
+      unless log_string =~ /Records: \(((\d+)( \| [\w:]+: \d+)*)\); (.+)/
         abort("invalid line: #{log_string.strip}")  
       end
 


### PR DESCRIPTION
``` ruby
      unless log_string =~ /Records: \(((\d+)( \| \w+: \d+)*)\); (.+)/
        abort("invalid line: #{log_string.strip}")  
      end
```

this matcher fails with name spaced models 
`invalid line: [Memory Usage] PID: xxxx Project: xxx User: xxx Mem: 526704.0 Records: (635 | Project::Item: 101 | LoginInformation: 00...`

also no need to search each line in the file when we can grep for `Memory Usage`
